### PR TITLE
Fix typo in downloadEpisode comment

### DIFF
--- a/app.js
+++ b/app.js
@@ -165,7 +165,7 @@ const sendToTelegram = async (feedItem, channelName) => {
 };
 
 /**
- * Decarga un episodio al servidor para luego procesar su metadata
+ * Descarga un episodio al servidor para luego procesar su metadata
  * @param {String} episodeUrl - La url del episodio a descargar
  * @param {String} episodePath - La ruta local donde almacenarlo
  * @param {String} folder - El nombre de la carpeta a descargar


### PR DESCRIPTION
## Summary
- fix comment typo for `downloadEpisode`

## Testing
- `npm test` *(fails: no test script)*

------
https://chatgpt.com/codex/tasks/task_e_683f915190b8833190dea658dcbc02d4