### PR TITLE
Fix upload error logging

### DIFF
--- a/app.js
+++ b/app.js
@@ -158,7 +158,18 @@ const sendToTelegram = async (feedItem, channelName) => {
         return success;
     } catch (err) {
         logError(`${episodeNumber} Failed to upload. ${err.message ?? err}`);
-        await DB.registerUpload(episodeNumber, err.response?.body?.description ?? err.message, false, '', channel, title, caption, url);
+        const uploadStatus = {
+            archivo: episodeNumber,
+            obs: err.response?.body?.description ?? err.message,
+            exito: false,
+            fileId: '',
+            channel,
+            title: pathToTitle(fileName),
+            caption,
+            url,
+            message_id: ''
+        };
+        await DB.registerUpload(uploadStatus);
 
         throw err;
     }


### PR DESCRIPTION
## Summary
- construct an upload status object in the failure path of `sendToTelegram`
- pass that object to `DB.registerUpload`

## Testing
- `npm test` *(fails: missing test script)*

------
https://chatgpt.com/codex/tasks/task_e_683f91a430e08331b145b2f3ffd3b309