### PR TITLE
Fix deploy: source nvm in non-interactive SSH

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,7 +80,16 @@ jobs:
           DEPLOY_PM2_NAME: ${{ secrets.DEPLOY_PM2_NAME }}
         run: |
           ssh -i ~/.ssh/id_deploy "${DEPLOY_USER}@${DEPLOY_HOST}" bash -s <<EOF
-            set -euo pipefail
+            set -eo pipefail
+
+            # Non-interactive SSH sessions skip .bashrc, so nvm isn't loaded
+            # automatically and npm/pm2 would resolve to the legacy system
+            # node instead of the nvm-managed Node 24. Source nvm explicitly.
+            export NVM_DIR="\$HOME/.nvm"
+            # shellcheck disable=SC1091
+            [ -s "\$NVM_DIR/nvm.sh" ] && . "\$NVM_DIR/nvm.sh"
+            nvm use default
+
             cd "${DEPLOY_PATH}"
             git fetch --all --prune
             git reset --hard origin/master

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "delsolbot",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "Integration between radio station RSS feeds and Telegram bot to publish in the corresponding Telegram channels",
   "main": "app.js",
   "keywords": [


### PR DESCRIPTION
The deploy job SSHes in with a quoted command, which creates a non-interactive, non-login bash session. That session skips ~/.bashrc, so nvm isn't loaded and `node`/`npm` resolve to whatever /usr/bin/node is — on the production droplet, a legacy system Node 10 from the OS image. Modern npm/lockfile refused, the deploy aborted before pm2 restart, and the live process (started interactively with nvm's Node 20) kept running on borrowed time.

Source nvm explicitly before running anything, then `nvm use default`. Future bumps to Node 25/26 only require `nvm alias default <new>` on the droplet — the workflow picks it up automatically.

Also drop `-u` from `set -euo pipefail`. nvm.sh references possibly-unset vars on some versions and fails under `-u`. Kept `-e` and `pipefail` for the fail-fast behavior that matters.